### PR TITLE
Set minimum approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ steps:
     with:
       secret: ${{ github.TOKEN }}
       approvers: user1,user2
-      minimum_approvals: 1
+      minimum-approvals: 1
 ```
 
 - `approvers` is a comma-delimited list of all required approvers.
-- `minimum_approvals` is an integer that sets the minimum number of approvals required to progress the workflow. Defaults to ALL approvers.
+- `minimum-approvals` is an integer that sets the minimum number of approvals required to progress the workflow. Defaults to ALL approvers.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ steps:
     with:
       secret: ${{ github.TOKEN }}
       approvers: user1,user2
+      minimum_approvals: 1
 ```
 
-`approvers` is a comma-delimited list of all required approvers.
+- `approvers` is a comma-delimited list of all required approvers.
+- `minimum_approvals` is an integer that sets the minimum number of approvals required to progress the workflow. Defaults to ALL approvers.

--- a/action.yaml
+++ b/action.yaml
@@ -7,7 +7,7 @@ inputs:
   secret:
     description: Secret
     required: true
-  minimum_approvals:
+  minimum-approvals:
     description: Minimum number of approvals to progress workflow
     required: false
 runs:

--- a/action.yaml
+++ b/action.yaml
@@ -7,6 +7,9 @@ inputs:
   secret:
     description: Secret
     required: true
+  minimum_approvals:
+    description: Minimum number of approvals to progress workflow
+    required: false
 runs:
   using: docker
   image: docker://ghcr.io/trstringer/manual-approval:1.1.3

--- a/approval_test.go
+++ b/approval_test.go
@@ -146,6 +146,18 @@ func TestApprovalFromComments(t *testing.T) {
 			expectedStatus:   approvalStatusApproved,
 			minimumApprovals: 2,
 		},
+		{
+			name: "multi_approver_approvals_less_than_minimum",
+			comments: []*github.IssueComment{
+				{
+					User: &github.User{Login: &login1},
+					Body: &bodyApproved,
+				},
+			},
+			approvers:        []string{login1, login2, login3},
+			expectedStatus:   approvalStatusPending,
+			minimumApprovals: 2,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/approval_test.go
+++ b/approval_test.go
@@ -9,15 +9,17 @@ import (
 func TestApprovalFromComments(t *testing.T) {
 	login1 := "login1"
 	login2 := "login2"
+	login3 := "login3"
 	bodyApproved := "Approved"
 	bodyDenied := "Denied"
 	bodyPending := "not approval or denial"
 
 	testCases := []struct {
-		name           string
-		comments       []*github.IssueComment
-		approvers      []string
-		expectedStatus approvalStatus
+		name             string
+		comments         []*github.IssueComment
+		approvers        []string
+		minimumApprovals int
+		expectedStatus   approvalStatus
 	}{
 		{
 			name: "single_approver_single_comment_approved",
@@ -112,11 +114,43 @@ func TestApprovalFromComments(t *testing.T) {
 			approvers:      []string{login1, login2},
 			expectedStatus: approvalStatusDenied,
 		},
+		{
+			name: "multi_approver_minimum_one_approval",
+			comments: []*github.IssueComment{
+				{
+					User: &github.User{Login: &login1},
+					Body: &bodyPending,
+				},
+				{
+					User: &github.User{Login: &login2},
+					Body: &bodyApproved,
+				},
+			},
+			approvers:        []string{login1, login2},
+			expectedStatus:   approvalStatusApproved,
+			minimumApprovals: 1,
+		},
+		{
+			name: "multi_approver_minimum_two_approvals",
+			comments: []*github.IssueComment{
+				{
+					User: &github.User{Login: &login1},
+					Body: &bodyApproved,
+				},
+				{
+					User: &github.User{Login: &login2},
+					Body: &bodyApproved,
+				},
+			},
+			approvers:        []string{login1, login2, login3},
+			expectedStatus:   approvalStatusApproved,
+			minimumApprovals: 2,
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual, err := approvalFromComments(testCase.comments, testCase.approvers)
+			actual, err := approvalFromComments(testCase.comments, testCase.approvers, testCase.minimumApprovals)
 			if err != nil {
 				t.Fatalf("error getting approval from comments: %v", err)
 			}

--- a/constants.go
+++ b/constants.go
@@ -5,11 +5,12 @@ import "time"
 const (
 	pollingInterval time.Duration = 10 * time.Second
 
-	envVarRepoFullName string = "GITHUB_REPOSITORY"
-	envVarRunID        string = "GITHUB_RUN_ID"
-	envVarRepoOwner    string = "GITHUB_REPOSITORY_OWNER"
-	envVarToken        string = "INPUT_SECRET"
-	envVarApprovers    string = "INPUT_APPROVERS"
+	envVarRepoFullName     string = "GITHUB_REPOSITORY"
+	envVarRunID            string = "GITHUB_RUN_ID"
+	envVarRepoOwner        string = "GITHUB_REPOSITORY_OWNER"
+	envVarToken            string = "INPUT_SECRET"
+	envVarApprovers        string = "INPUT_APPROVERS"
+	envVarMinimumApprovals string = "INPUT_MINIMUM_APPROVALS"
 )
 
 var (

--- a/constants.go
+++ b/constants.go
@@ -10,7 +10,7 @@ const (
 	envVarRepoOwner        string = "GITHUB_REPOSITORY_OWNER"
 	envVarToken            string = "INPUT_SECRET"
 	envVarApprovers        string = "INPUT_APPROVERS"
-	envVarMinimumApprovals string = "INPUT_MINIMUM_APPROVALS"
+	envVarMinimumApprovals string = "INPUT_MINIMUM-APPROVALS"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 	}
 
 	if minimumApprovals > len(approvers) {
-		fmt.Printf("warning: minimum required approvals (%v) is greater than the total number of approvers (%v)\n", minimumApprovals, len(approvers))
+		fmt.Printf("error: minimum required approvals (%v) is greater than the total number of approvers (%v)\n", minimumApprovals, len(approvers))
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -37,7 +37,22 @@ func main() {
 	fmt.Printf("Required approvers: %s\n", requiredApproversRaw)
 	approvers := strings.Split(requiredApproversRaw, ",")
 
-	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers)
+	minimumApprovalsRaw := os.Getenv(envVarMinimumApprovals)
+	minimumApprovals := len(approvers)
+	if minimumApprovalsRaw != "" {
+		minimumApprovals, err = strconv.Atoi(minimumApprovalsRaw)
+		if err != nil {
+			fmt.Printf("error parsing minimum number of approvals: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	if minimumApprovals > len(approvers) {
+		fmt.Printf("warning: minimum required approvals (%v) is greater than the total number of approvers (%v)\n", minimumApprovals, len(approvers))
+		os.Exit(1)
+	}
+
+	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals)
 	if err != nil {
 		fmt.Printf("error creating approval environment: %v\n", err)
 		os.Exit(1)
@@ -57,7 +72,7 @@ commentLoop:
 			os.Exit(1)
 		}
 
-		approved, err := approvalFromComments(comments, approvers)
+		approved, err := approvalFromComments(comments, approvers, minimumApprovals)
 		if err != nil {
 			fmt.Printf("error getting approval from comments: %v\n", err)
 			os.Exit(1)


### PR DESCRIPTION
This PR allows setting a minimum number of approvals before the workflow continues, via a new input parameter `minimum_approvals`.

This means you can now list an entire team of users as `approvers`, but only need one of them to approve the manual step.

If the new parameter is not set, the existing behaviour is preserved - all reviewers are required to approve.

I have updated the test suite to take this change into account, and I compiled my own docker image to test in a separate repository.

Passing workflow: https://github.com/elmundio87/manual-approval-test/runs/5706511606?check_suite_focus=true
Associated issue: https://github.com/elmundio87/manual-approval-test/issues/5

Thanks for the great Github Action!
