### PR TITLE
Close issue if action cancelled

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func setupCloseHandler(ctx context.Context, apprv *approvalEnvironment, client *
 	go func(ctx context.Context, apprv *approvalEnvironment, client *github.Client) {
 		<-killSignal
 		newState := "closed"
-		closeComment := "Workflow cancelled, closing issue"
+		closeComment := "Workflow cancelled, closing issue."
 		fmt.Println(closeComment)
 		_, _, err := client.Issues.Edit(ctx, apprv.repoOwner, apprv.repo, apprv.approvalIssueNumber, &github.IssueRequest{State: &newState})
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ func handleInterrupt(client *github.Client, ctx context.Context, apprv *approval
 }
 
 func newCommentLoopChannel(ctx context.Context, apprv *approvalEnvironment, client *github.Client, approvers []string, minimumApprovals int) chan int {
-
 	channel := make(chan int)
 	go func() {
 		for {

--- a/main.go
+++ b/main.go
@@ -47,7 +47,6 @@ func newGithubClient(ctx context.Context) *github.Client {
 }
 
 func main() {
-
 	repoFullName := os.Getenv(envVarRepoFullName)
 	runID, err := strconv.Atoi(os.Getenv(envVarRunID))
 	if err != nil {
@@ -143,4 +142,6 @@ commentLoop:
 
 		time.Sleep(pollingInterval)
 	}
+
+	fmt.Println("Workflow manual approval completed")
 }


### PR DESCRIPTION
If the workflow is cancelled due to user intervention or job timeout, this will ensure that the associated GitHub issue is closed, before the action exits.

This is achieved by intercepting the kill signal that the Docker container receives on job cancellation, and moving the main comment loop into a separate goroutine.

This should prevent issues being left behind when pipeline runs are cancelled.

I am using this in conjunction with the `timeout-minutes` parameter, to prevent approvals from running for excessive amounts of time.