### PR TITLE
Add debug statement for issue create

### DIFF
--- a/approval.go
+++ b/approval.go
@@ -57,6 +57,14 @@ Respond %s to continue workflow or %s to cancel.`,
 		formatAcceptedWords(deniedWords),
 	)
 	var err error
+	fmt.Printf(
+		"Creating issue in repo %s/%s with the following content:\nTitle: %s\nApprovers: %s\nBody:\n%s",
+		a.repoOwner,
+		a.repo,
+		issueTitle,
+		a.approvers,
+		issueBody,
+	)
 	a.approvalIssue, _, err = a.client.Issues.Create(ctx, a.repoOwner, a.repo, &github.IssueRequest{
 		Title:     &issueTitle,
 		Body:      &issueBody,


### PR DESCRIPTION
This PR adds a debug logging statement to stdout prior to creating the
issue. This will help troubleshoot issues, such as a GitHub API http/422
response status with invalid message.