### PR TITLE
Add newline to debug logging statement

### DIFF
--- a/approval.go
+++ b/approval.go
@@ -58,7 +58,7 @@ Respond %s to continue workflow or %s to cancel.`,
 	)
 	var err error
 	fmt.Printf(
-		"Creating issue in repo %s/%s with the following content:\nTitle: %s\nApprovers: %s\nBody:\n%s",
+		"Creating issue in repo %s/%s with the following content:\nTitle: %s\nApprovers: %s\nBody:\n%s\n",
 		a.repoOwner,
 		a.repo,
 		issueTitle,


### PR DESCRIPTION
There was a missing newline in the log. This commit adds the newline so
that there is the proper line breaks.