### PR TITLE
Fix bug with not accepting newlines

### DIFF
--- a/approval.go
+++ b/approval.go
@@ -126,7 +126,7 @@ func approversIndex(approvers []string, name string) int {
 
 func isApproved(commentBody string) (bool, error) {
 	for _, approvedWord := range approvedWords {
-		matched, err := regexp.MatchString(fmt.Sprintf("(?i)^%s[.!]?$", approvedWord), commentBody)
+		matched, err := regexp.MatchString(fmt.Sprintf("(?i)^%s[.!]*\n*$", approvedWord), commentBody)
 		if err != nil {
 			return false, err
 		}

--- a/approval_test.go
+++ b/approval_test.go
@@ -216,6 +216,11 @@ func TestApprovedCommentBody(t *testing.T) {
 			isSuccess:   true,
 		},
 		{
+			name:        "approved_titlecase_multi_exclamation",
+			commentBody: "Approved!!",
+			isSuccess:   true,
+		},
+		{
 			name:        "approved_titlecase_question",
 			commentBody: "Approved?",
 			isSuccess:   false,
@@ -229,6 +234,21 @@ func TestApprovedCommentBody(t *testing.T) {
 			name:        "sentence_without_keyword",
 			commentBody: "this is just some random comment",
 			isSuccess:   false,
+		},
+		{
+			name:        "approved_with_newline",
+			commentBody: "approved\n",
+			isSuccess:   true,
+		},
+		{
+			name:        "approved_with_exclamation_newline",
+			commentBody: "approved!\n",
+			isSuccess:   true,
+		},
+		{
+			name:        "approved_with_multi_exclamation_multi_newline",
+			commentBody: "approved!!!\n\n\n",
+			isSuccess:   true,
 		},
 	}
 


### PR DESCRIPTION
Prior to this PR, if there was a newline (or multiple newline
characters) at the end of the keyword then it wouldn't match. With this
fix any number of newlines at the end of the keyword match will now be
considered for approve or deny.

Fixes #8.