### PR TITLE
Add limitations to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,9 @@ steps:
 - `approvers` is a comma-delimited list of all required approvers.
 - `minimum-approvals` is an integer that sets the minimum number of approvals required to progress the workflow. Defaults to ALL approvers.
 - `issue-title` is a string that will be appened to the title of the issue.
+
+## Limitations
+
+* While the workflow is paused, it will still continue to consume a concurrent job allocation out of the [max concurrent jobs](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits)
+* A job (including a paused job) will be failed [after 6 hours](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits)
+* A paused job is still running compute/instance/virtual machine and will continue to incur costs


### PR DESCRIPTION
Add the specific limitations and considerations to the project
documentation. Closes #2.