### PR TITLE
Add markdown files to ignored files in the CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   ci:


### PR DESCRIPTION
The CI pipeline should not be running if only markdown files are
modified, so they should be ignored.