### PR TITLE
Troubleshoot and log failed group expansion

### DIFF
--- a/approvers.go
+++ b/approvers.go
@@ -45,8 +45,10 @@ func retrieveApprovers(client *github.Client, repoOwner string) ([]string, error
 }
 
 func expandGroupFromUser(client *github.Client, org, userOrTeam string) []string {
+	fmt.Printf("Attempting to expand user %s/%s as a group (may not succeed)\n", org, userOrTeam)
 	users, _, err := client.Teams.ListTeamMembersBySlug(context.Background(), org, userOrTeam, &github.TeamListTeamMembersOptions{})
-	if err != nil || len(users) == 0 {
+	if err != nil {
+		fmt.Printf("%v\n", err)
 		return nil
 	}
 


### PR DESCRIPTION
Currently group expansion is failing. I suspect this is due to workflow
permissions, as this succeeds locally. This additional logging should
show unexpected errors that aren't just a non-group expansion.