### PR TITLE
Option to exclude workflow initiator (`GITHUB_ACTOR`) as an approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ steps:
       approvers: user1,user2,org-team1
       minimum-approvals: 1
       issue-title: "Deploying v1.3.5 to prod from staging"
-      exclude-workflow-initiator-as-approver: false # Optional, defaults to false
+      exclude-workflow-initiator-as-approver: false
 ```
 
 - `approvers` is a comma-delimited list of all required approvers. An approver can either be a user or an org team. (*Note: Required approvers must have the ability to be set as approvers in the repository. If you add an approver that doesn't have this permission then you would receive an HTTP/402 Validation Failed error when running this action*)
 - `minimum-approvals` is an integer that sets the minimum number of approvals required to progress the workflow. Defaults to ALL approvers.
 - `issue-title` is a string that will be appended to the title of the issue.
-- `exclude-workflow-initiator-as-approver` is a boolean that indicates if the workflow initiator (determined by the `GITHUB_ACTOR` environment variable) should be filtered from the final list of approvers. Set this to `true` to prevent users in the `approvers` list from being able to self-approve workflows.
+- `exclude-workflow-initiator-as-approver` is a boolean that indicates if the workflow initiator (determined by the `GITHUB_ACTOR` environment variable) should be filtered from the final list of approvers. This is optional and defaults to `false`. Set this to `true` to prevent users in the `approvers` list from being able to self-approve workflows.
 
 ## Org team approver
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ steps:
       approvers: user1,user2,org-team1
       minimum-approvals: 1
       issue-title: "Deploying v1.3.5 to prod from staging"
+      allow-workflow-initiator-as-approver: true # Optional, defaults to true
 ```
 
 - `approvers` is a comma-delimited list of all required approvers. An approver can either be a user or an org team. (*Note: Required approvers must have the ability to be set as approvers in the repository. If you add an approver that doesn't have this permission then you would receive an HTTP/402 Validation Failed error when running this action*)
 - `minimum-approvals` is an integer that sets the minimum number of approvals required to progress the workflow. Defaults to ALL approvers.
 - `issue-title` is a string that will be appended to the title of the issue.
+- `allow-workflow-initiator-as-approver` is a boolean that indicates if the workflow initiator (determined by the `GITHUB_ACTOR` environment variable) should be included in the final list of approvers. Set this to `false` to prevent users in the `approvers` list from being able to self-approve workflows.
 
 ## Org team approver
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ steps:
 
 - `approvers` is a comma-delimited list of all required approvers. An approver can either be a user or an org team. (*Note: Required approvers must have the ability to be set as approvers in the repository. If you add an approver that doesn't have this permission then you would receive an HTTP/402 Validation Failed error when running this action*)
 - `minimum-approvals` is an integer that sets the minimum number of approvals required to progress the workflow. Defaults to ALL approvers.
-- `issue-title` is a string that will be appened to the title of the issue.
+- `issue-title` is a string that will be appended to the title of the issue.
 
 ## Org team approver
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ steps:
       approvers: user1,user2,org-team1
       minimum-approvals: 1
       issue-title: "Deploying v1.3.5 to prod from staging"
-      allow-workflow-initiator-as-approver: true # Optional, defaults to true
+      exclude-workflow-initiator-as-approver: false # Optional, defaults to false
 ```
 
 - `approvers` is a comma-delimited list of all required approvers. An approver can either be a user or an org team. (*Note: Required approvers must have the ability to be set as approvers in the repository. If you add an approver that doesn't have this permission then you would receive an HTTP/402 Validation Failed error when running this action*)
 - `minimum-approvals` is an integer that sets the minimum number of approvals required to progress the workflow. Defaults to ALL approvers.
 - `issue-title` is a string that will be appended to the title of the issue.
-- `allow-workflow-initiator-as-approver` is a boolean that indicates if the workflow initiator (determined by the `GITHUB_ACTOR` environment variable) should be included in the final list of approvers. Set this to `false` to prevent users in the `approvers` list from being able to self-approve workflows.
+- `exclude-workflow-initiator-as-approver` is a boolean that indicates if the workflow initiator (determined by the `GITHUB_ACTOR` environment variable) should be filtered from the final list of approvers. Set this to `true` to prevent users in the `approvers` list from being able to self-approve workflows.
 
 ## Org team approver
 

--- a/action.yaml
+++ b/action.yaml
@@ -16,9 +16,9 @@ inputs:
   issue-title:
     description: The custom subtitle for the issue
     required: false
-  allow-workflow-initiator-as-approver:
+  exclude-workflow-initiator-as-approver:
     description: Whether or not to filter out the user who initiated the workflow as an approver if they are in the approvers list
-    default: true
+    default: false
 runs:
   using: docker
   image: docker://ghcr.io/trstringer/manual-approval:1.7.0

--- a/action.yaml
+++ b/action.yaml
@@ -17,7 +17,7 @@ inputs:
     description: The custom subtitle for the issue
     required: false
   allow-workflow-initiator-as-approver:
-    description: Whether or not to include the user who initiated the workflow as an approver.
+    description: Whether or not to filter out the user who initiated the workflow as an approver if they are in the approvers list
     default: true
 runs:
   using: docker

--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,9 @@ inputs:
   issue-title:
     description: The custom subtitle for the issue
     required: false
+  allow-workflow-initiator-as-approver:
+    description: Whether or not to include the user who initiated the workflow as an approver.
+    default: true
 runs:
   using: docker
   image: docker://ghcr.io/trstringer/manual-approval:1.7.0

--- a/approvers.go
+++ b/approvers.go
@@ -11,9 +11,14 @@ import (
 )
 
 func retrieveApprovers(client *github.Client, repoOwner string) ([]string, error) {
-	approvers := []string{}
 	workflowInitiator := os.Getenv(envVarWorkflowInitiator)
+	shouldIncludeWorkflowInitiatorRaw := os.Getenv(envVarAllowWorkflowInitiatorAsApprover)
+	shouldIncludeWorkflowInitiator, parseBoolErr := strconv.ParseBool(shouldIncludeWorkflowInitiatorRaw)
+	if parseBoolErr != nil {
+		return nil, fmt.Errorf("error parsing allow-workflow-initiator-as-approver flag: %w", parseBoolErr)
+	}
 
+	approvers := []string{}
 	requiredApproversRaw := os.Getenv(envVarApprovers)
 	requiredApprovers := strings.Split(requiredApproversRaw, ",")
 
@@ -22,10 +27,10 @@ func retrieveApprovers(client *github.Client, repoOwner string) ([]string, error
 	}
 
 	for _, approverUser := range requiredApprovers {
-		expandedUsers := expandGroupFromUser(client, repoOwner, approverUser, workflowInitiator)
+		expandedUsers := expandGroupFromUser(client, repoOwner, approverUser, workflowInitiator, shouldIncludeWorkflowInitiator)
 		if expandedUsers != nil {
 			approvers = append(approvers, expandedUsers...)
-		} else if strings.EqualFold(workflowInitiator, approverUser) {
+		} else if strings.EqualFold(workflowInitiator, approverUser) && !shouldIncludeWorkflowInitiator {
 			fmt.Printf("Not adding user '%s' as an approver as they are the workflow initiator\n", approverUser)
 		} else {
 			approvers = append(approvers, approverUser)
@@ -51,7 +56,7 @@ func retrieveApprovers(client *github.Client, repoOwner string) ([]string, error
 	return approvers, nil
 }
 
-func expandGroupFromUser(client *github.Client, org, userOrTeam string, workflowInitiator string) []string {
+func expandGroupFromUser(client *github.Client, org, userOrTeam string, workflowInitiator string, shouldIncludeWorkflowInitiator bool) []string {
 	fmt.Printf("Attempting to expand user %s/%s as a group (may not succeed)\n", org, userOrTeam)
 	users, _, err := client.Teams.ListTeamMembersBySlug(context.Background(), org, userOrTeam, &github.TeamListTeamMembersOptions{})
 	if err != nil {
@@ -62,7 +67,7 @@ func expandGroupFromUser(client *github.Client, org, userOrTeam string, workflow
 	userNames := make([]string, 0, len(users))
 	for _, user := range users {
 		userName := user.GetLogin()
-		if strings.EqualFold(userName, workflowInitiator) {
+		if strings.EqualFold(userName, workflowInitiator) && !shouldIncludeWorkflowInitiator {
 			fmt.Printf("Not adding user '%s' from group '%s' as an approver as they are the workflow initiator\n", userName, userOrTeam)
 		} else {
 			userNames = append(userNames, userName)

--- a/approvers.go
+++ b/approvers.go
@@ -15,7 +15,7 @@ func retrieveApprovers(client *github.Client, repoOwner string) ([]string, error
 	shouldExcludeWorkflowInitiatorRaw := os.Getenv(envVarExcludeWorkflowInitiatorAsApprover)
 	shouldExcludeWorkflowInitiator, parseBoolErr := strconv.ParseBool(shouldExcludeWorkflowInitiatorRaw)
 	if parseBoolErr != nil {
-		return nil, fmt.Errorf("error parsing allow-workflow-initiator-as-approver flag: %w", parseBoolErr)
+		return nil, fmt.Errorf("error parsing exclude-workflow-initiator-as-approver flag: %w", parseBoolErr)
 	}
 
 	approvers := []string{}

--- a/approvers.go
+++ b/approvers.go
@@ -61,11 +61,11 @@ func expandGroupFromUser(client *github.Client, org, userOrTeam string, workflow
 
 	userNames := make([]string, 0, len(users))
 	for _, user := range users {
-		username := user.GetLogin()
-		if strings.EqualFold(username, workflowInitiator) {
-			fmt.Printf("Not adding user '%s' from group '%s' as an approver as they are the workflow initiator\n", username, userOrTeam)
+		userName := user.GetLogin()
+		if strings.EqualFold(userName, workflowInitiator) {
+			fmt.Printf("Not adding user '%s' from group '%s' as an approver as they are the workflow initiator\n", userName, userOrTeam)
 		} else {
-			userNames = append(userNames, username)
+			userNames = append(userNames, userName)
 		}
 	}
 

--- a/approvers.go
+++ b/approvers.go
@@ -25,10 +25,9 @@ func retrieveApprovers(client *github.Client, repoOwner string) ([]string, error
 		expandedUsers := expandGroupFromUser(client, repoOwner, approverUser, workflowInitiator)
 		if expandedUsers != nil {
 			approvers = append(approvers, expandedUsers...)
+		} else if strings.EqualFold(workflowInitiator, approverUser) {
+			fmt.Printf("Not adding user '%s' as an approver as they are the workflow initiator\n", approverUser)
 		} else {
-			if strings.EqualFold(workflowInitiator, approverUser) {
-				fmt.Printf("Not adding user '%s' as an approver as they are the workflow initiator\n", approverUser)
-			}
 			approvers = append(approvers, approverUser)
 		}
 	}

--- a/approvers.go
+++ b/approvers.go
@@ -12,19 +12,23 @@ import (
 
 func retrieveApprovers(client *github.Client, repoOwner string) ([]string, error) {
 	approvers := []string{}
+	workflowInitiator := os.Getenv(envVarWorkflowInitiator)
 
 	requiredApproversRaw := os.Getenv(envVarApprovers)
 	requiredApprovers := strings.Split(requiredApproversRaw, ",")
 
 	for i := range requiredApprovers {
-		requiredApprovers[i] = strings.TrimSpace(requiredApprovers[i]) 
+		requiredApprovers[i] = strings.TrimSpace(requiredApprovers[i])
 	}
-	
+
 	for _, approverUser := range requiredApprovers {
-		expandedUsers := expandGroupFromUser(client, repoOwner, approverUser)
+		expandedUsers := expandGroupFromUser(client, repoOwner, approverUser, workflowInitiator)
 		if expandedUsers != nil {
 			approvers = append(approvers, expandedUsers...)
 		} else {
+			if strings.EqualFold(workflowInitiator, approverUser) {
+				fmt.Printf("Not adding user '%s' as an approver as they are the workflow initiator\n", approverUser)
+			}
 			approvers = append(approvers, approverUser)
 		}
 	}
@@ -48,7 +52,7 @@ func retrieveApprovers(client *github.Client, repoOwner string) ([]string, error
 	return approvers, nil
 }
 
-func expandGroupFromUser(client *github.Client, org, userOrTeam string) []string {
+func expandGroupFromUser(client *github.Client, org, userOrTeam string, workflowInitiator string) []string {
 	fmt.Printf("Attempting to expand user %s/%s as a group (may not succeed)\n", org, userOrTeam)
 	users, _, err := client.Teams.ListTeamMembersBySlug(context.Background(), org, userOrTeam, &github.TeamListTeamMembersOptions{})
 	if err != nil {
@@ -58,7 +62,12 @@ func expandGroupFromUser(client *github.Client, org, userOrTeam string) []string
 
 	userNames := make([]string, 0, len(users))
 	for _, user := range users {
-		userNames = append(userNames, user.GetLogin())
+		username := user.GetLogin()
+		if strings.EqualFold(username, workflowInitiator) {
+			fmt.Printf("Not adding user '%s' from group '%s' as an approver as they are the workflow initiator\n", username, userOrTeam)
+		} else {
+			userNames = append(userNames, username)
+		}
 	}
 
 	return userNames

--- a/constants.go
+++ b/constants.go
@@ -5,15 +5,15 @@ import "time"
 const (
 	pollingInterval time.Duration = 10 * time.Second
 
-	envVarRepoFullName                     string = "GITHUB_REPOSITORY"
-	envVarRunID                            string = "GITHUB_RUN_ID"
-	envVarRepoOwner                        string = "GITHUB_REPOSITORY_OWNER"
-	envVarWorkflowInitiator                string = "GITHUB_ACTOR"
-	envVarToken                            string = "INPUT_SECRET"
-	envVarApprovers                        string = "INPUT_APPROVERS"
-	envVarMinimumApprovals                 string = "INPUT_MINIMUM-APPROVALS"
-	envVarIssueTitle                       string = "INPUT_ISSUE-TITLE"
-	envVarAllowWorkflowInitiatorAsApprover string = "INPUT_ALLOW-WORKFLOW-INITIATOR-AS-APPROVER"
+	envVarRepoFullName                       string = "GITHUB_REPOSITORY"
+	envVarRunID                              string = "GITHUB_RUN_ID"
+	envVarRepoOwner                          string = "GITHUB_REPOSITORY_OWNER"
+	envVarWorkflowInitiator                  string = "GITHUB_ACTOR"
+	envVarToken                              string = "INPUT_SECRET"
+	envVarApprovers                          string = "INPUT_APPROVERS"
+	envVarMinimumApprovals                   string = "INPUT_MINIMUM-APPROVALS"
+	envVarIssueTitle                         string = "INPUT_ISSUE-TITLE"
+	envVarExcludeWorkflowInitiatorAsApprover string = "INPUT_EXCLUDE-WORKFLOW-INITIATOR-AS-APPROVER"
 )
 
 var (

--- a/constants.go
+++ b/constants.go
@@ -5,13 +5,14 @@ import "time"
 const (
 	pollingInterval time.Duration = 10 * time.Second
 
-	envVarRepoFullName     string = "GITHUB_REPOSITORY"
-	envVarRunID            string = "GITHUB_RUN_ID"
-	envVarRepoOwner        string = "GITHUB_REPOSITORY_OWNER"
-	envVarToken            string = "INPUT_SECRET"
-	envVarApprovers        string = "INPUT_APPROVERS"
-	envVarMinimumApprovals string = "INPUT_MINIMUM-APPROVALS"
-	envVarIssueTitle       string = "INPUT_ISSUE-TITLE"
+	envVarRepoFullName      string = "GITHUB_REPOSITORY"
+	envVarRunID             string = "GITHUB_RUN_ID"
+	envVarRepoOwner         string = "GITHUB_REPOSITORY_OWNER"
+	envVarWorkflowInitiator string = "GITHUB_ACTOR"
+	envVarToken             string = "INPUT_SECRET"
+	envVarApprovers         string = "INPUT_APPROVERS"
+	envVarMinimumApprovals  string = "INPUT_MINIMUM-APPROVALS"
+	envVarIssueTitle        string = "INPUT_ISSUE-TITLE"
 )
 
 var (

--- a/constants.go
+++ b/constants.go
@@ -5,14 +5,15 @@ import "time"
 const (
 	pollingInterval time.Duration = 10 * time.Second
 
-	envVarRepoFullName      string = "GITHUB_REPOSITORY"
-	envVarRunID             string = "GITHUB_RUN_ID"
-	envVarRepoOwner         string = "GITHUB_REPOSITORY_OWNER"
-	envVarWorkflowInitiator string = "GITHUB_ACTOR"
-	envVarToken             string = "INPUT_SECRET"
-	envVarApprovers         string = "INPUT_APPROVERS"
-	envVarMinimumApprovals  string = "INPUT_MINIMUM-APPROVALS"
-	envVarIssueTitle        string = "INPUT_ISSUE-TITLE"
+	envVarRepoFullName                     string = "GITHUB_REPOSITORY"
+	envVarRunID                            string = "GITHUB_RUN_ID"
+	envVarRepoOwner                        string = "GITHUB_REPOSITORY_OWNER"
+	envVarWorkflowInitiator                string = "GITHUB_ACTOR"
+	envVarToken                            string = "INPUT_SECRET"
+	envVarApprovers                        string = "INPUT_APPROVERS"
+	envVarMinimumApprovals                 string = "INPUT_MINIMUM-APPROVALS"
+	envVarIssueTitle                       string = "INPUT_ISSUE-TITLE"
+	envVarAllowWorkflowInitiatorAsApprover string = "INPUT_ALLOW-WORKFLOW-INITIATOR-AS-APPROVER"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func newGithubClient(ctx context.Context) (*github.Client, error) {
 	apiUrl, apiUrlPresent := os.LookupEnv("GITHUB_API_URL")
 
 	if serverUrlPresent {
-		if ! apiUrlPresent {
+		if !apiUrlPresent {
 			apiUrl = serverUrl
 		}
 		return github.NewEnterpriseClient(apiUrl, serverUrl, tc)


### PR DESCRIPTION
Hi there, thanks for creating this GH Action - it's come in handy for some workflows over at @leaselock :) 

We have a use case in which we want to allow a team of users to approve a step. However, if the user who initiates the workflow is also part of the team, we don't want to allow the initiator to self-approve. 

This workflow initiator is exposed as a default environment variable `GITHUB_ACTOR`, so we added a small change to filter that user out. 

I figured I'd share this PR as it might be useful for other users too. Perhaps we can toggle this behavior based on an input flag `allow_workflow_initiator_as_approver: true|false`?

![Screen Shot 2022-11-08 at 3 20 35 PM](https://user-images.githubusercontent.com/5664347/200697781-7e14ffd2-8f5d-4309-a905-beecf0e37164.png)  


