### PR TITLE
Fix bug with period in org team name

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,4 +21,4 @@ inputs:
     default: false
 runs:
   using: docker
-  image: docker://ghcr.io/trstringer/manual-approval-test:1.7.0
+  image: docker://ghcr.io/trstringer/manual-approval:1.7.0

--- a/action.yaml
+++ b/action.yaml
@@ -21,4 +21,4 @@ inputs:
     default: false
 runs:
   using: docker
-  image: docker://ghcr.io/trstringer/manual-approval-test:1.7.1-rc.1
+  image: docker://ghcr.io/trstringer/manual-approval-test:1.7.0

--- a/action.yaml
+++ b/action.yaml
@@ -21,4 +21,4 @@ inputs:
     default: false
 runs:
   using: docker
-  image: docker://ghcr.io/trstringer/manual-approval:1.7.0
+  image: docker://ghcr.io/trstringer/manual-approval-test:1.7.1-rc.1

--- a/approvers.go
+++ b/approvers.go
@@ -58,7 +58,13 @@ func retrieveApprovers(client *github.Client, repoOwner string) ([]string, error
 
 func expandGroupFromUser(client *github.Client, org, userOrTeam string, workflowInitiator string, shouldExcludeWorkflowInitiator bool) []string {
 	fmt.Printf("Attempting to expand user %s/%s as a group (may not succeed)\n", org, userOrTeam)
-	users, _, err := client.Teams.ListTeamMembersBySlug(context.Background(), org, userOrTeam, &github.TeamListTeamMembersOptions{})
+
+	// GitHub replaces periods in the team name with hyphens. If a period is
+	// passed to the request it would result in a 404. So we need to replace
+	// and occurrences with a hyphen.
+	formattedUserOrteam := strings.ReplaceAll(userOrTeam, ".", "-")
+
+	users, _, err := client.Teams.ListTeamMembersBySlug(context.Background(), org, formattedUserOrteam, &github.TeamListTeamMembersOptions{})
 	if err != nil {
 		fmt.Printf("%v\n", err)
 		return nil

--- a/approvers.go
+++ b/approvers.go
@@ -62,9 +62,9 @@ func expandGroupFromUser(client *github.Client, org, userOrTeam string, workflow
 	// GitHub replaces periods in the team name with hyphens. If a period is
 	// passed to the request it would result in a 404. So we need to replace
 	// and occurrences with a hyphen.
-	formattedUserOrteam := strings.ReplaceAll(userOrTeam, ".", "-")
+	formattedUserOrTeam := strings.ReplaceAll(userOrTeam, ".", "-")
 
-	users, _, err := client.Teams.ListTeamMembersBySlug(context.Background(), org, formattedUserOrteam, &github.TeamListTeamMembersOptions{})
+	users, _, err := client.Teams.ListTeamMembersBySlug(context.Background(), org, formattedUserOrTeam, &github.TeamListTeamMembersOptions{})
 	if err != nil {
 		fmt.Printf("%v\n", err)
 		return nil


### PR DESCRIPTION
Currently if you have an org team name with a period in it, the team will not be found with a 404 response. This is because the GitHub API requires that the periods are replaced with hyphens. This PR fixes this behavior and closes #55.