### PR TITLE
Add new input 'issue-body'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ steps:
       approvers: user1,user2,org-team1
       minimum-approvals: 1
       issue-title: "Deploying v1.3.5 to prod from staging"
+      issue-body: "Please approve or deny the deployment of version v1.3.5."
       exclude-workflow-initiator-as-approver: false
 ```
 
 - `approvers` is a comma-delimited list of all required approvers. An approver can either be a user or an org team. (*Note: Required approvers must have the ability to be set as approvers in the repository. If you add an approver that doesn't have this permission then you would receive an HTTP/402 Validation Failed error when running this action*)
 - `minimum-approvals` is an integer that sets the minimum number of approvals required to progress the workflow. Defaults to ALL approvers.
 - `issue-title` is a string that will be appended to the title of the issue.
+- `issue-body` is a string that will be prepended to the body of the issue.
 - `exclude-workflow-initiator-as-approver` is a boolean that indicates if the workflow initiator (determined by the `GITHUB_ACTOR` environment variable) should be filtered from the final list of approvers. This is optional and defaults to `false`. Set this to `true` to prevent users in the `approvers` list from being able to self-approve workflows.
 
 ## Org team approver

--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,9 @@ inputs:
   issue-title:
     description: The custom subtitle for the issue
     required: false
+  issue-body:
+    description: The custom body for the issue
+    required: false
   exclude-workflow-initiator-as-approver:
     description: Whether or not to filter out the user who initiated the workflow as an approver if they are in the approvers list
     default: false

--- a/approval.go
+++ b/approval.go
@@ -18,11 +18,12 @@ type approvalEnvironment struct {
 	approvalIssue       *github.Issue
 	approvalIssueNumber int
 	issueTitle          string
+	issueBody           string
 	issueApprovers      []string
 	minimumApprovals    int
 }
 
-func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner string, runID int, approvers []string, minimumApprovals int, issueTitle string) (*approvalEnvironment, error) {
+func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner string, runID int, approvers []string, minimumApprovals int, issueTitle, issueBody string) (*approvalEnvironment, error) {
 	repoOwnerAndName := strings.Split(repoFullName, "/")
 	if len(repoOwnerAndName) != 2 {
 		return nil, fmt.Errorf("repo owner and name in unexpected format: %s", repoFullName)
@@ -38,6 +39,7 @@ func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner strin
 		issueApprovers:   approvers,
 		minimumApprovals: minimumApprovals,
 		issueTitle:       issueTitle,
+		issueBody:        issueBody,
 	}, nil
 }
 
@@ -63,6 +65,11 @@ Respond %s to continue workflow or %s to cancel.`,
 		formatAcceptedWords(approvedWords),
 		formatAcceptedWords(deniedWords),
 	)
+
+	if a.issueBody != "" {
+		issueBody = fmt.Sprintf("%s\n\n%s", a.issueBody, issueBody)
+	}
+
 	var err error
 	fmt.Printf(
 		"Creating issue in repo %s/%s with the following content:\nTitle: %s\nApprovers: %s\nBody:\n%s\n",

--- a/constants.go
+++ b/constants.go
@@ -13,6 +13,7 @@ const (
 	envVarApprovers                          string = "INPUT_APPROVERS"
 	envVarMinimumApprovals                   string = "INPUT_MINIMUM-APPROVALS"
 	envVarIssueTitle                         string = "INPUT_ISSUE-TITLE"
+	envVarIssueBody                          string = "INPUT_ISSUE-BODY"
 	envVarExcludeWorkflowInitiatorAsApprover string = "INPUT_EXCLUDE-WORKFLOW-INITIATOR-AS-APPROVER"
 )
 

--- a/main.go
+++ b/main.go
@@ -171,6 +171,7 @@ func main() {
 	}
 
 	issueTitle := os.Getenv(envVarIssueTitle)
+	issueBody := os.Getenv(envVarIssueBody)
 	minimumApprovalsRaw := os.Getenv(envVarMinimumApprovals)
 	minimumApprovals := 0
 	if minimumApprovalsRaw != "" {
@@ -180,7 +181,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals, issueTitle)
+	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals, issueTitle, issueBody)
 	if err != nil {
 		fmt.Printf("error creating approval environment: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Similar to the 'issue-title' input, 'issue-body' allows to put custom text to
the body of the approval issue.

`make lint` and `make build` are working, but I do not know how to further test
this... So any help in testing this change is much appreciated.

This might fix issues #69 and #49.
