### PR TITLE
Allow for configurable poll interval to GitHub API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ steps:
       issue-title: "Deploying v1.3.5 to prod from staging"
       issue-body: "Please approve or deny the deployment of version v1.3.5."
       exclude-workflow-initiator-as-approver: false
+      poll-interval: 30
 ```
 
 - `approvers` is a comma-delimited list of all required approvers. An approver can either be a user or an org team. (*Note: Required approvers must have the ability to be set as approvers in the repository. If you add an approver that doesn't have this permission then you would receive an HTTP/402 Validation Failed error when running this action*)
@@ -41,6 +42,7 @@ steps:
 - `issue-title` is a string that will be appended to the title of the issue.
 - `issue-body` is a string that will be prepended to the body of the issue.
 - `exclude-workflow-initiator-as-approver` is a boolean that indicates if the workflow initiator (determined by the `GITHUB_ACTOR` environment variable) should be filtered from the final list of approvers. This is optional and defaults to `false`. Set this to `true` to prevent users in the `approvers` list from being able to self-approve workflows.
+- `poll-interval` is an integer that sets the rate at which the Github API will be polled for updates (in seconds). Defaults to 10.
 
 ## Org team approver
 

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,9 @@ inputs:
   exclude-workflow-initiator-as-approver:
     description: Whether or not to filter out the user who initiated the workflow as an approver if they are in the approvers list
     default: false
+  poll-interval:
+    description: The frequency, in seconds, at which to poll the GitHub API for updates to comments on issues
+    default: 10
 runs:
   using: docker
   image: docker://ghcr.io/trstringer/manual-approval:1.8.0

--- a/approval.go
+++ b/approval.go
@@ -21,7 +21,7 @@ type approvalEnvironment struct {
 	issueBody           string
 	issueApprovers      []string
 	minimumApprovals    int
-	pollInterval				time.Duration
+	pollInterval        time.Duration
 }
 
 func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner string, runID int, approvers []string, minimumApprovals int, issueTitle, issueBody string, pollInterval time.Duration) (*approvalEnvironment, error) {
@@ -41,7 +41,7 @@ func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner strin
 		minimumApprovals: minimumApprovals,
 		issueTitle:       issueTitle,
 		issueBody:        issueBody,
-		pollInterval:			pollInterval
+		pollInterval:     pollInterval
 	}, nil
 }
 

--- a/approval.go
+++ b/approval.go
@@ -21,9 +21,10 @@ type approvalEnvironment struct {
 	issueBody           string
 	issueApprovers      []string
 	minimumApprovals    int
+	pollInterval				time.Duration
 }
 
-func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner string, runID int, approvers []string, minimumApprovals int, issueTitle, issueBody string) (*approvalEnvironment, error) {
+func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner string, runID int, approvers []string, minimumApprovals int, issueTitle, issueBody string, pollInterval time.Duration) (*approvalEnvironment, error) {
 	repoOwnerAndName := strings.Split(repoFullName, "/")
 	if len(repoOwnerAndName) != 2 {
 		return nil, fmt.Errorf("repo owner and name in unexpected format: %s", repoFullName)
@@ -40,6 +41,7 @@ func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner strin
 		minimumApprovals: minimumApprovals,
 		issueTitle:       issueTitle,
 		issueBody:        issueBody,
+		pollInterval:			pollInterval
 	}, nil
 }
 

--- a/approval.go
+++ b/approval.go
@@ -41,7 +41,7 @@ func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner strin
 		minimumApprovals: minimumApprovals,
 		issueTitle:       issueTitle,
 		issueBody:        issueBody,
-		pollInterval:     pollInterval
+		pollInterval:     pollInterval,
 	}, nil
 }
 

--- a/constants.go
+++ b/constants.go
@@ -3,8 +3,6 @@ package main
 import "time"
 
 const (
-	pollingInterval time.Duration = 10 * time.Second
-
 	envVarRepoFullName                       string = "GITHUB_REPOSITORY"
 	envVarRunID                              string = "GITHUB_RUN_ID"
 	envVarRepoOwner                          string = "GITHUB_REPOSITORY_OWNER"
@@ -15,6 +13,7 @@ const (
 	envVarIssueTitle                         string = "INPUT_ISSUE-TITLE"
 	envVarIssueBody                          string = "INPUT_ISSUE-BODY"
 	envVarExcludeWorkflowInitiatorAsApprover string = "INPUT_EXCLUDE-WORKFLOW-INITIATOR-AS-APPROVER"
+	envVarPollInterval                       string = "INPUT_POLL-INTERVAL"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func newCommentLoopChannel(ctx context.Context, apprv *approvalEnvironment, clie
 				close(channel)
 			}
 
-			time.Sleep(pollingInterval)
+			time.Sleep(apprv.pollInterval)
 		}
 	}()
 	return channel
@@ -181,7 +181,18 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals, issueTitle, issueBody)
+
+	pollIntervalRaw := os.Getenv(envVarPollInterval)
+	pollInterval := 10 * time.Second
+	if pollIntervalRaw != "" {
+		pollInterval, err = strconv.Atoi(pollIntervalRaw) * time.Second
+		if err != nil {
+			fmt.Printf("error parsing poll interval: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals, issueTitle, issueBody, pollInterval)
 	if err != nil {
 		fmt.Printf("error creating approval environment: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This change adds a new input `poll-interval` which allows users to configure the rate at which requests are made to the Github API.

Default value is left as 10 seconds for backwards compatibility

Fixes #78 