### PR TITLE
fix(#75): display corect base URL if using GHE

### DIFF
--- a/approval.go
+++ b/approval.go
@@ -44,7 +44,7 @@ func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner strin
 }
 
 func (a approvalEnvironment) runURL() string {
-	return fmt.Sprintf("https://github.com/%s/actions/runs/%d", a.repoFullName, a.runID)
+	return fmt.Sprintf("%s%s/actions/runs/%d", a.client.BaseURL.String(), a.repoFullName, a.runID)
 }
 
 func (a *approvalEnvironment) createApprovalIssue(ctx context.Context) error {


### PR DESCRIPTION
It was displaying the GH URL even though the GHE was configured, using the client.baseURL will correctly display a correct value.

https://pkg.go.dev/github.com/google/go-github/v50/github#Client