### PR TITLE
Feature/issue label and file preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ steps:
       exclude-workflow-initiator-as-approver: false
       additional-approved-words: ''
       additional-denied-words: ''
+      labels: ''
+      additional-issue-body-file: '{base64}.{file extension}'
 ```
 
 - `approvers` is a comma-delimited list of all required approvers. An approver can either be a user or an org team. (*Note: Required approvers must have the ability to be set as approvers in the repository. If you add an approver that doesn't have this permission then you would receive an HTTP/402 Validation Failed error when running this action*)
@@ -45,6 +47,8 @@ steps:
 - `exclude-workflow-initiator-as-approver` is a boolean that indicates if the workflow initiator (determined by the `GITHUB_ACTOR` environment variable) should be filtered from the final list of approvers. This is optional and defaults to `false`. Set this to `true` to prevent users in the `approvers` list from being able to self-approve workflows.
 - `additional-approved-words` is a comma separated list of strings to expand the dictionary of words that indicate approval. This is optional and defaults to an empty string.
 - `additional-denied-words` is a comma separated list of strings to expand the dictionary of words that indicate denial. This is optional and defaults to an empty string.
+- `additional-denied-words` is a comma separated list of strings to set labels of issue.
+- `additional-issue-body-file` is a string that will decode base64 to show the preview of the file inside body.
 
 ### Using Custom Words
 

--- a/action.yaml
+++ b/action.yaml
@@ -32,8 +32,8 @@ inputs:
     description: Issue labels
     required: false
   additional-issue-body-file:
-    description: The custom body for the issue using file as preview
+    description: The custom body for the issue to show file preview
     required: false
 runs:
   using: docker
-  image: docker://docker.io/reynandaptr/manual-approval:1.9.2
+  image: docker://ghcr.io/trstringer/manual-approval:1.9.0

--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,9 @@ inputs:
   additional-denied-words:
     description: Comma separated list of words that can be used to deny beyond the defaults.
     default: ''
+  labels:
+    description: Issue labels
+    required: false
 runs:
   using: docker
-  image: docker://ghcr.io/trstringer/manual-approval:1.9.0
+  image: docker://docker.io/reynandaptr/manual-approval:1.9.1

--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,9 @@ inputs:
   labels:
     description: Issue labels
     required: false
+  additional-issue-body-file:
+    description: The custom body for the issue using file as preview
+    required: false
 runs:
   using: docker
-  image: docker://docker.io/reynandaptr/manual-approval:1.9.1
+  image: docker://docker.io/reynandaptr/manual-approval:1.9.2

--- a/approval.go
+++ b/approval.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"regexp"
 	"strings"
@@ -10,21 +11,22 @@ import (
 )
 
 type approvalEnvironment struct {
-	client              *github.Client
-	repoFullName        string
-	repo                string
-	repoOwner           string
-	runID               int
-	approvalIssue       *github.Issue
-	approvalIssueNumber int
-	issueTitle          string
-	issueBody           string
-	issueApprovers      []string
-	minimumApprovals    int
-	labels              []string
+	client               *github.Client
+	repoFullName         string
+	repo                 string
+	repoOwner            string
+	runID                int
+	approvalIssue        *github.Issue
+	approvalIssueNumber  int
+	issueTitle           string
+	issueBody            string
+	issueApprovers       []string
+	minimumApprovals     int
+	labels               []string
+	issueBodyFilePreview string
 }
 
-func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner string, runID int, approvers []string, minimumApprovals int, issueTitle, issueBody string, labels []string) (*approvalEnvironment, error) {
+func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner string, runID int, approvers []string, minimumApprovals int, issueTitle, issueBody string, labels []string, issueBodyFilePreview string) (*approvalEnvironment, error) {
 	repoOwnerAndName := strings.Split(repoFullName, "/")
 	if len(repoOwnerAndName) != 2 {
 		return nil, fmt.Errorf("repo owner and name in unexpected format: %s", repoFullName)
@@ -32,16 +34,17 @@ func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner strin
 	repo := repoOwnerAndName[1]
 
 	return &approvalEnvironment{
-		client:           client,
-		repoFullName:     repoFullName,
-		repo:             repo,
-		repoOwner:        repoOwner,
-		runID:            runID,
-		issueApprovers:   approvers,
-		minimumApprovals: minimumApprovals,
-		issueTitle:       issueTitle,
-		issueBody:        issueBody,
-		labels:           labels,
+		client:               client,
+		repoFullName:         repoFullName,
+		repo:                 repo,
+		repoOwner:            repoOwner,
+		runID:                runID,
+		issueApprovers:       approvers,
+		minimumApprovals:     minimumApprovals,
+		issueTitle:           issueTitle,
+		issueBody:            issueBody,
+		labels:               labels,
+		issueBodyFilePreview: issueBodyFilePreview,
 	}, nil
 }
 
@@ -67,6 +70,22 @@ Respond %s to continue workflow or %s to cancel.`,
 		formatAcceptedWords(approvedWords),
 		formatAcceptedWords(deniedWords),
 	)
+
+	if a.issueBodyFilePreview != "" {
+		s := strings.Split(a.issueBodyFilePreview, ".")
+		if len(s) == 2 {
+			ext := s[1]
+			content, err := base64.StdEncoding.DecodeString(s[0])
+			if err != nil {
+				fmt.Printf("%s\n", err.Error())
+			} else {
+				issueBody = fmt.Sprintf(`%s%s
+%s
+%s
+%s`, "```", ext, string(content), "````", issueBody)
+			}
+		}
+	}
 
 	if a.issueBody != "" {
 		issueBody = fmt.Sprintf("%s\n\n%s", a.issueBody, issueBody)

--- a/approval.go
+++ b/approval.go
@@ -21,9 +21,10 @@ type approvalEnvironment struct {
 	issueBody           string
 	issueApprovers      []string
 	minimumApprovals    int
+	labels              []string
 }
 
-func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner string, runID int, approvers []string, minimumApprovals int, issueTitle, issueBody string) (*approvalEnvironment, error) {
+func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner string, runID int, approvers []string, minimumApprovals int, issueTitle, issueBody string, labels []string) (*approvalEnvironment, error) {
 	repoOwnerAndName := strings.Split(repoFullName, "/")
 	if len(repoOwnerAndName) != 2 {
 		return nil, fmt.Errorf("repo owner and name in unexpected format: %s", repoFullName)
@@ -40,6 +41,7 @@ func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner strin
 		minimumApprovals: minimumApprovals,
 		issueTitle:       issueTitle,
 		issueBody:        issueBody,
+		labels:           labels,
 	}, nil
 }
 
@@ -72,17 +74,19 @@ Respond %s to continue workflow or %s to cancel.`,
 
 	var err error
 	fmt.Printf(
-		"Creating issue in repo %s/%s with the following content:\nTitle: %s\nApprovers: %s\nBody:\n%s\n",
+		"Creating issue in repo %s/%s with the following content:\nTitle: %s\nApprovers: %s\nLabels: %s\nBody:\n%s\n",
 		a.repoOwner,
 		a.repo,
 		issueTitle,
 		a.issueApprovers,
+		a.labels,
 		issueBody,
 	)
 	a.approvalIssue, _, err = a.client.Issues.Create(ctx, a.repoOwner, a.repo, &github.IssueRequest{
 		Title:     &issueTitle,
 		Body:      &issueBody,
 		Assignees: &a.issueApprovers,
+		Labels:    &a.labels,
 	})
 	if err != nil {
 		return err

--- a/constants.go
+++ b/constants.go
@@ -22,6 +22,7 @@ const (
 	envVarAdditionalApprovedWords            string = "INPUT_ADDITIONAL-APPROVED-WORDS"
 	envVarAdditionalDeniedWords              string = "INPUT_ADDITIONAL-DENIED-WORDS"
 	envVarLabels                             string = "INPUT_LABELS"
+	envVarAdditionalIssueBodyFile            string = "INPUT_ADDITIONAL-ISSUE-BODY-FILE"
 )
 
 var (

--- a/constants.go
+++ b/constants.go
@@ -21,6 +21,7 @@ const (
 	envVarExcludeWorkflowInitiatorAsApprover string = "INPUT_EXCLUDE-WORKFLOW-INITIATOR-AS-APPROVER"
 	envVarAdditionalApprovedWords            string = "INPUT_ADDITIONAL-APPROVED-WORDS"
 	envVarAdditionalDeniedWords              string = "INPUT_ADDITIONAL-DENIED-WORDS"
+	envVarLabels                             string = "INPUT_LABELS"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v43/github"
@@ -172,6 +173,7 @@ func main() {
 
 	issueTitle := os.Getenv(envVarIssueTitle)
 	issueBody := os.Getenv(envVarIssueBody)
+	labels := os.Getenv(envVarLabels)
 	minimumApprovalsRaw := os.Getenv(envVarMinimumApprovals)
 	minimumApprovals := 0
 	if minimumApprovalsRaw != "" {
@@ -181,7 +183,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals, issueTitle, issueBody)
+	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals, issueTitle, issueBody, strings.Split(labels, ","))
 	if err != nil {
 		fmt.Printf("error creating approval environment: %v\n", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -174,6 +174,7 @@ func main() {
 	issueTitle := os.Getenv(envVarIssueTitle)
 	issueBody := os.Getenv(envVarIssueBody)
 	labels := os.Getenv(envVarLabels)
+	issueBodyFilePreview := os.Getenv(envVarAdditionalIssueBodyFile)
 	minimumApprovalsRaw := os.Getenv(envVarMinimumApprovals)
 	minimumApprovals := 0
 	if minimumApprovalsRaw != "" {
@@ -183,7 +184,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals, issueTitle, issueBody, strings.Split(labels, ","))
+	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals, issueTitle, issueBody, strings.Split(labels, ","), issueBodyFilePreview)
 	if err != nil {
 		fmt.Printf("error creating approval environment: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
- Allow user set labels of issue
- Allow user see the file preview before continue the pipeline

Example: 
```yaml
labels: migration
additional-issue-body-file: ZW52aXJvbm1lbnQ6IHRlc3QKc3FsczoKICAgIC0gQUxURVIgVEFCTEUgInN0b3BzIiBBTFRFUiBDT0xVTU4gImNvb3JkaW5hdGUiIFRZUEUgZ2VvbWV0cnkoUG9pbnQsNDMyNikgVVNJTkcgImNvb3JkaW5hdGUiOjpnZW9tZXRyeShQb2ludCw0MzI2KQogICAgLSBBTFRFUiBUQUJMRSAic3RvcHMiIEFMVEVSIENPTFVNTiAiY29vcmRpbmF0ZSIgU0VUIERFRkFVTFQgbnVsbAo=.yaml
```
![image](https://user-images.githubusercontent.com/22214317/230833446-f16dd409-f0e5-4a91-9f40-5b3ba95b0abb.png)
