### PR TITLE
Fix issue URL in job log

### DIFF
--- a/approval.go
+++ b/approval.go
@@ -89,7 +89,7 @@ Respond %s to continue workflow or %s to cancel.`,
 	}
 	a.approvalIssueNumber = a.approvalIssue.GetNumber()
 
-	fmt.Printf("Issue created: %s\n", a.approvalIssue.GetURL())
+	fmt.Printf("Issue created: %s\n", a.approvalIssue.GetHTMLURL())
 	return nil
 }
 


### PR DESCRIPTION
`GetURL` returns the API URL of the issue, e.g.:

```
Issue created: https://api.github.com/repos/user/repo/issues/123456
```

It would be more useful to put the HTML URL (for human use) in the job log:

```
Issue created: https://github.com/user/repo/issues/123456
```

API docs: https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue

```js
{
  // ...
  "url": "https://api.github.com/repos/octocat/Hello-World/issues/1347",
  // ...
  "html_url": "https://github.com/octocat/Hello-World/issues/1347",
  // ...
}
```