### PR TITLE
Allow anyone to approve

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -6,7 +6,7 @@ branding:
 inputs:
   approvers:
     description: Required approvers
-    required: true
+    required: false
   secret:
     description: Secret
     required: true
@@ -21,7 +21,7 @@ inputs:
     required: false
   exclude-workflow-initiator-as-approver:
     description: Whether or not to filter out the user who initiated the workflow as an approver if they are in the approvers list
-    default: false
+    default: 'false'
   additional-approved-words:
     description: Comma separated list of words that can be used to approve beyond the defaults.
     default: ''

--- a/approval.go
+++ b/approval.go
@@ -56,6 +56,11 @@ func (a *approvalEnvironment) createApprovalIssue(ctx context.Context) error {
 		issueTitle = fmt.Sprintf("%s: %s", issueTitle, a.issueTitle)
 	}
 
+	issueApproversText := "Anyone can approve."
+	if len(a.issueApprovers) > 0 {
+		issueApproversText = fmt.Sprintf("%s", a.issueApprovers)
+	}
+
 	issueBody := fmt.Sprintf(`Workflow is pending manual review.
 URL: %s
 
@@ -63,7 +68,7 @@ Required approvers: %s
 
 Respond %s to continue workflow or %s to cancel.`,
 		a.runURL(),
-		a.issueApprovers,
+		issueApproversText,
 		formatAcceptedWords(approvedWords),
 		formatAcceptedWords(deniedWords),
 	)

--- a/approval_test.go
+++ b/approval_test.go
@@ -18,6 +18,7 @@ func TestApprovalFromComments(t *testing.T) {
 		name             string
 		comments         []*github.IssueComment
 		approvers        []string
+		disallowedUsers  []string
 		minimumApprovals int
 		expectedStatus   approvalStatus
 	}{
@@ -162,7 +163,7 @@ func TestApprovalFromComments(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual, err := approvalFromComments(testCase.comments, testCase.approvers, testCase.minimumApprovals)
+			actual, err := approvalFromComments(testCase.comments, testCase.approvers, testCase.minimumApprovals, testCase.disallowedUsers)
 			if err != nil {
 				t.Fatalf("error getting approval from comments: %v", err)
 			}

--- a/approvers.go
+++ b/approvers.go
@@ -20,7 +20,10 @@ func retrieveApprovers(client *github.Client, repoOwner string) ([]string, []str
 
 	approvers := []string{}
 	requiredApproversRaw := os.Getenv(envVarApprovers)
-	requiredApprovers := strings.Split(requiredApproversRaw, ",")
+	requiredApprovers := []string{}
+	if requiredApproversRaw != "" {
+		requiredApprovers = strings.Split(requiredApproversRaw, ",")
+	}
 
 	minimumApprovalsRaw := os.Getenv(envVarMinimumApprovals)
 	minimumApprovals := len(approvers)

--- a/approvers.go
+++ b/approvers.go
@@ -10,17 +10,31 @@ import (
 	"github.com/google/go-github/v43/github"
 )
 
-func retrieveApprovers(client *github.Client, repoOwner string) ([]string, error) {
+func retrieveApprovers(client *github.Client, repoOwner string) ([]string, []string, error) {
 	workflowInitiator := os.Getenv(envVarWorkflowInitiator)
 	shouldExcludeWorkflowInitiatorRaw := os.Getenv(envVarExcludeWorkflowInitiatorAsApprover)
 	shouldExcludeWorkflowInitiator, parseBoolErr := strconv.ParseBool(shouldExcludeWorkflowInitiatorRaw)
 	if parseBoolErr != nil {
-		return nil, fmt.Errorf("error parsing exclude-workflow-initiator-as-approver flag: %w", parseBoolErr)
+		return nil, nil, fmt.Errorf("error parsing exclude-workflow-initiator-as-approver flag: %w", parseBoolErr)
 	}
 
 	approvers := []string{}
 	requiredApproversRaw := os.Getenv(envVarApprovers)
 	requiredApprovers := strings.Split(requiredApproversRaw, ",")
+
+	minimumApprovalsRaw := os.Getenv(envVarMinimumApprovals)
+	minimumApprovals := len(approvers)
+
+	var disallowedUsers []string
+	if shouldExcludeWorkflowInitiator {
+		disallowedUsers = []string{workflowInitiator}
+	} else {
+		disallowedUsers = []string{}
+	}
+
+	if len(requiredApprovers) == 0 {
+		return []string{}, disallowedUsers, nil
+	}
 
 	for i := range requiredApprovers {
 		requiredApprovers[i] = strings.TrimSpace(requiredApprovers[i])
@@ -39,21 +53,19 @@ func retrieveApprovers(client *github.Client, repoOwner string) ([]string, error
 
 	approvers = deduplicateUsers(approvers)
 
-	minimumApprovalsRaw := os.Getenv(envVarMinimumApprovals)
-	minimumApprovals := len(approvers)
 	var err error
 	if minimumApprovalsRaw != "" {
 		minimumApprovals, err = strconv.Atoi(minimumApprovalsRaw)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing minimum number of approvals: %w", err)
+			return nil, nil, fmt.Errorf("error parsing minimum number of approvals: %w", err)
 		}
 	}
 
 	if minimumApprovals > len(approvers) {
-		return nil, fmt.Errorf("error: minimum required approvals (%d) is greater than the total number of approvers (%d)", minimumApprovals, len(approvers))
+		return nil, nil, fmt.Errorf("error: minimum required approvals (%d) is greater than the total number of approvers (%d)", minimumApprovals, len(approvers))
 	}
 
-	return approvers, nil
+	return approvers, disallowedUsers, nil
 }
 
 func expandGroupFromUser(client *github.Client, org, userOrTeam string, workflowInitiator string, shouldExcludeWorkflowInitiator bool) []string {

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func newCommentLoopChannel(ctx context.Context, apprv *approvalEnvironment, clie
 				close(channel)
 			}
 
-			approved, err := approvalFromComments(comments, apprv.issueApprovers, apprv.minimumApprovals)
+			approved, err := approvalFromComments(comments, apprv.issueApprovers, apprv.minimumApprovals, apprv.disallowedUsers)
 			if err != nil {
 				fmt.Printf("error getting approval from comments: %v\n", err)
 				channel <- 1
@@ -133,10 +133,6 @@ func validateInput() error {
 		missingEnvVars = append(missingEnvVars, envVarToken)
 	}
 
-	if os.Getenv(envVarApprovers) == "" {
-		missingEnvVars = append(missingEnvVars, envVarApprovers)
-	}
-
 	if len(missingEnvVars) > 0 {
 		return fmt.Errorf("missing env vars: %v", missingEnvVars)
 	}
@@ -164,7 +160,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	approvers, err := retrieveApprovers(client, repoOwner)
+	approvers, disallowedUsers, err := retrieveApprovers(client, repoOwner)
 	if err != nil {
 		fmt.Printf("error retrieving approvers: %v\n", err)
 		os.Exit(1)
@@ -181,7 +177,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals, issueTitle, issueBody)
+	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals, issueTitle, issueBody, disallowedUsers)
 	if err != nil {
 		fmt.Printf("error creating approval environment: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Make the `approvers` field optional, and allow anyone to approve if it's empty. 

I had to rework `approvalFromComments` to make this work, since it worked by removing names from the required approvers list until the list was small enough. 

closes https://github.com/trstringer/manual-approval/issues/108