### PR TITLE
Add timeout-minutes as a valid input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,9 @@ inputs:
   minimum-approvals:
     description: Minimum number of approvals to progress workflow
     required: false
+  timeout-minutes:
+    description: Force timeout of your workflow pause
+    required: false
   issue-title:
     description: The custom subtitle for the issue
     required: false


### PR DESCRIPTION
Currently when running action with input of timeout-minutes warning of Unexpected input will be shown in the workflow run.
<img width="950" alt="Pasted Graphic 1" src="https://github.com/trstringer/manual-approval/assets/9288093/85443d44-bcb6-4393-a60d-dce03aa294c4">


It will fix https://github.com/trstringer/manual-approval/issues/111