### PR TITLE
feat: use blocks for issue-body

### DIFF
--- a/approval.go
+++ b/approval.go
@@ -60,12 +60,14 @@ func (a *approvalEnvironment) createApprovalIssue(ctx context.Context) error {
 		issueTitle = fmt.Sprintf("%s: %s", issueTitle, a.issueTitle)
 	}
 
-	issueBody := fmt.Sprintf(`Workflow is pending manual review.
-URL: %s
+	issueBody := fmt.Sprintf(`> Workflow is pending manual review.
+> URL: %s
 
-Required approvers: %s
+> [!IMPORTANT]
+> Required approvers: %s
 
-Respond %s to continue workflow or %s to cancel.`,
+> [!TIP]
+> Respond %s to continue workflow or %s to cancel.`,
 		a.runURL(),
 		a.issueApprovers,
 		formatAcceptedWords(approvedWords),
@@ -73,8 +75,9 @@ Respond %s to continue workflow or %s to cancel.`,
 	)
 
 	if a.issueBody != "" {
-		issueBody = fmt.Sprintf("%s\n\n%s", a.issueBody, issueBody)
+		issueBody = fmt.Sprintf(">%s\n>\n%s", a.issueBody, issueBody)
 	}
+	issueBody = fmt.Sprintf(">[!NOTE]\n%s", issueBody)
 
 	var err error
 	fmt.Printf(


### PR DESCRIPTION
Uses colored blocks to make data more clear

Example Issue:
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/693820b1-3244-44c6-b5d4-014590e37965">
