### PR TITLE
Make closing issue comment more accurate; cleanup README

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,9 +13,6 @@ inputs:
   minimum-approvals:
     description: Minimum number of approvals to progress workflow
     required: false
-  timeout-minutes:
-    description: Force timeout of your workflow pause
-    required: false
   issue-title:
     description: The custom subtitle for the issue
     required: false

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func setActionOutput(name, value string) error {
 func handleInterrupt(ctx context.Context, client *github.Client, apprv *approvalEnvironment) {
 	newState := "closed"
 	closeComment := "Workflow cancelled, closing issue."
+
 	fmt.Println(closeComment)
 	_, _, err := client.Issues.CreateComment(ctx, apprv.targetRepoOwner, apprv.targetRepoName, apprv.approvalIssueNumber, &github.IssueComment{
 		Body: &closeComment,
@@ -65,7 +66,7 @@ func newCommentLoopChannel(ctx context.Context, apprv *approvalEnvironment, clie
 			switch approved {
 			case approvalStatusApproved:
 				newState := "closed"
-				closeComment := "All approvers have approved, continuing workflow and closing this issue."
+				closeComment := fmt.Sprintf("The required number of approvals (%d) has been met; continuing workflow and closing this issue.", apprv.minimumApprovals)
 				_, _, err := client.Issues.CreateComment(ctx, apprv.targetRepoOwner, apprv.targetRepoName, apprv.approvalIssueNumber, &github.IssueComment{
 					Body: &closeComment,
 				})


### PR DESCRIPTION
- removed `timeout-minutes` from action.yaml as it does nothing and obfuscates the fact that `timeout-minutes` is a GitHub action-specific input
- updated README to indicate that workflows expire after 35 days now, and reference the limitations section
- repeat important limitations mentioned elsewhere in the limitations section
- resolve https://github.com/trstringer/manual-approval/issues/114
- resolve #135 


<img width="942" alt="image" src="https://github.com/user-attachments/assets/240338ae-4e0c-4f7c-a096-c139946ace6b" />
