### PR TITLE
Remove default title if custom title is provided

### DIFF
--- a/approval.go
+++ b/approval.go
@@ -57,7 +57,7 @@ func (a *approvalEnvironment) createApprovalIssue(ctx context.Context) error {
 	issueTitle := fmt.Sprintf("Manual approval required for workflow run %d", a.runID)
 
 	if a.issueTitle != "" {
-		issueTitle = fmt.Sprintf("%s: %s", issueTitle, a.issueTitle)
+		issueTitle = a.issueTitle
 	}
 
 	issueBody := fmt.Sprintf(`Workflow is pending manual review.


### PR DESCRIPTION
- Previously they were combined, however the caller should be allowed to specify the title in full with the `issue-title` field. If a workflow ID is required, that can be supplied in the field as well (see example image)
- Introducing a field to remove the prefix feels like excess overhead
- resolve https://github.com/trstringer/manual-approval/issues/88

<img width="960" alt="Screenshot 2025-02-17 at 3 22 35 PM" src="https://github.com/user-attachments/assets/4e35ded2-df81-498a-9c3f-813559871797" />


