### PR TITLE
Make name comparison case-insensitive

### DIFF
--- a/approval.go
+++ b/approval.go
@@ -136,12 +136,12 @@ func (a *approvalEnvironment) SetActionOutputs(outputs map[string]string) (bool,
 	// two outputs from being written on the same line.
 	fileInfo, err := f.Stat()
 	if err != nil {
-			return false, err
+		return false, err
 	}
 	if fileInfo.Size() > 0 {
-			if _, err := f.WriteString("\n"); err != nil {
-					return false, err
-			}
+		if _, err := f.WriteString("\n"); err != nil {
+			return false, err
+		}
 	}
 
 	if _, err := f.WriteString(strings.Join(pairs, "\n")); err != nil {
@@ -194,7 +194,7 @@ func approvalFromComments(comments []*github.IssueComment, approvers []string, m
 
 func approversIndex(approvers []string, name string) int {
 	for idx, approver := range approvers {
-		if approver == name {
+		if strings.EqualFold(approver, name) {
 			return idx
 		}
 	}

--- a/approval_test.go
+++ b/approval_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-github/v43/github"
@@ -15,6 +16,8 @@ func TestApprovalFromComments(t *testing.T) {
 	bodyApproved := "Approved"
 	bodyDenied := "Denied"
 	bodyPending := "not approval or denial"
+
+	login1u := strings.ToUpper(login1)
 
 	testCases := []struct {
 		name             string
@@ -159,6 +162,17 @@ func TestApprovalFromComments(t *testing.T) {
 			approvers:        []string{login1, login2, login3},
 			expectedStatus:   approvalStatusPending,
 			minimumApprovals: 2,
+		},
+		{
+			name: "single_approver_single_comment_approved_case_insensitive",
+			comments: []*github.IssueComment{
+				{
+					User: &github.User{Login: &login1u},
+					Body: &bodyApproved,
+				},
+			},
+			approvers:      []string{login1},
+			expectedStatus: approvalStatusApproved,
 		},
 	}
 


### PR DESCRIPTION
This was [fun to debug](https://github.com/opensearch-project/sql-odbc/issues/89). In cases where people misconfigure the capitalization of usernames, the action fails to detect approvers. This PR makes comparison case insensitive. ([docs: strings.EqualFold](https://pkg.go.dev/strings#EqualFold)).

It can be trivially worked around for users by fixing the caps. It's just a small usability improvement.
