### PR TITLE
chore: update base image from alpine:3.14 (EOL) to alpine:3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /var/app
 RUN go mod tidy
 RUN CGO_ENABLED=0 go build -o app .
 
-FROM alpine:3.21
+FROM alpine:3.23
 LABEL org.opencontainers.image.source=https://github.com/trstringer/manual-approval
 RUN apk update && apk add ca-certificates
 COPY --from=builder /var/app/app /var/app/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /var/app
 RUN go mod tidy
 RUN CGO_ENABLED=0 go build -o app .
 
-FROM alpine:3.14
+FROM alpine:3.21
 LABEL org.opencontainers.image.source=https://github.com/trstringer/manual-approval
 RUN apk update && apk add ca-certificates
 COPY --from=builder /var/app/app /var/app/app


### PR DESCRIPTION
## Summary

- Updates `Dockerfile` base image from `alpine:3.14` to `alpine:3.23`
- Alpine 3.14 reached EOL in November 2024 and no longer receives security updates
- Alpine 3.23 is the latest stable release (EOL: 2027-11-01)

Closes #211

## Test plan

- [ ] CI passes (build + test + lint)
- [ ] Docker image builds successfully with `alpine:3.23`
- [ ] Action runs correctly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)