### PR TITLE
Modernize project to Go 1.25 and address security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM golang:1.24@sha256:d2d2bc1c84f7e60d7d2438a3836ae7d0c847f4888464e7ec9ba3a1339a1ee804 AS builder
+# not pinning the exact image digest to support multiple architecture builds without multiple Dockerfiles
+
+FROM golang:1.25 AS builder
 COPY . /var/app
 WORKDIR /var/app
 RUN go mod tidy
 RUN CGO_ENABLED=0 go build -o app .
 
-FROM alpine:3.23@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40
+FROM alpine:3.23
 LABEL org.opencontainers.image.source=https://github.com/trstringer/manual-approval
 RUN apk update && apk add ca-certificates
 COPY --from=builder /var/app/app /var/app/app

--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ test:
 
 .PHONY: lint
 lint:
-	docker run --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v2.1.6 golangci-lint run -v
+	docker run --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v2.10.1 golangci-lint run -v

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/trstringer/manual-approval
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-github/v43 v43.0.0
@@ -9,5 +9,5 @@ require (
 
 require (
 	github.com/google/go-querystring v1.1.0 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
+	golang.org/x/crypto v0.53.0 // indirect
 )


### PR DESCRIPTION
GO version bumped, 1.24 -> 1.25 in order to bump crypto package 0.45 -> 0.53

Warn: Project is vulnerable to: GO-2026-5005
Warn: Project is vulnerable to: GO-2026-5006
Warn: Project is vulnerable to: GO-2026-5013
Warn: Project is vulnerable to: GO-2026-5014
Warn: Project is vulnerable to: GO-2026-5015
Warn: Project is vulnerable to: GO-2026-5016
Warn: Project is vulnerable to: GO-2026-5017
Warn: Project is vulnerable to: GO-2026-5018
Warn: Project is vulnerable to: GO-2026-5019
Warn: Project is vulnerable to: GO-2026-5020
Warn: Project is vulnerable to: GO-2026-5021
Warn: Project is vulnerable to: GO-2026-5023
Warn: Project is vulnerable to: GO-2026-5033