### PR TITLE
Allow approval comments to include reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ steps:
       additional-approved-words: ''
       additional-denied-words: ''
       polling-interval-seconds: 10
+      allow-comment-reasons: false
 ```
 
 * `approvers` is a comma-delimited list of all required approvers. An approver can either be a user or an org team. (*Note: Required approvers must have the ability to be set as approvers in the repository. If you add an approver that doesn't have this permission then you would receive an HTTP/402 Validation Failed error when running this action*)
@@ -68,6 +69,8 @@ steps:
 * `additional-approved-words` is a comma separated list of strings to expand the dictionary of words that indicate approval. This is optional and defaults to an empty string.
 * `additional-denied-words` is a comma separated list of strings to expand the dictionary of words that indicate denial. This is optional and defaults to an empty string.
 * `polling-interval-seconds` is an integer that sets the number of seconds to wait between polling the GitHub API for approval status. This is optional and defaults to `10` seconds. Increase this value if you want to reduce API calls, or decrease it for faster response times.
+
+* `allow-comment-reasons` allows an approver to put the approval or denial keyword on the first line and explanatory text on later lines. It defaults to `false`, preserving the existing requirement that the whole comment contain only the decision keyword and optional punctuation. When enabled, only the first line determines the decision.
 
 > [!Note]
 > 1. If You are using issue-body-file-path then please make sure the file is reachable; for example, if the file is in your repo, then please checkout to your repo in the same job as the approval issue.

--- a/action.yaml
+++ b/action.yaml
@@ -57,6 +57,12 @@ inputs:
       comment will be treated as a denial. Disabled by default.
     required: false
     default: "false"
+  allow-comment-reasons:
+    description: >
+      If true, treat an approval or denial keyword on the first line as the
+      decision and allow explanatory text on later lines.
+    required: false
+    default: "false"
 outputs:
   issue-number:
     description: The number of the issue created

--- a/approval.go
+++ b/approval.go
@@ -27,9 +27,10 @@ type approvalEnvironment struct {
 	targetRepoName        string
 	failOnDenial          bool
 	closeIssueMeansDenial bool
+	allowCommentReasons   bool
 }
 
-func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner string, runID int, approvers []string, minimumApprovals int, issueTitle, issueBody string, targetRepoOwner string, targetRepoName string, failOnDenial bool, closeIssueMeansDenial bool, issueLabels []string) (*approvalEnvironment, error) {
+func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner string, runID int, approvers []string, minimumApprovals int, issueTitle, issueBody string, targetRepoOwner string, targetRepoName string, failOnDenial bool, closeIssueMeansDenial bool, allowCommentReasons bool, issueLabels []string) (*approvalEnvironment, error) {
 	repoOwnerAndName := strings.Split(repoFullName, "/")
 	if len(repoOwnerAndName) != 2 {
 		return nil, fmt.Errorf("repo owner and name in unexpected format: %s", repoFullName)
@@ -50,6 +51,7 @@ func newApprovalEnvironment(client *github.Client, repoFullName, repoOwner strin
 		targetRepoName:        targetRepoName,
 		failOnDenial:          failOnDenial,
 		closeIssueMeansDenial: closeIssueMeansDenial,
+		allowCommentReasons:   allowCommentReasons,
 		issueLabels:           issueLabels,
 	}, nil
 }
@@ -184,7 +186,7 @@ func (a *approvalEnvironment) SetActionOutputs(outputs map[string]string) (bool,
 	return true, nil
 }
 
-func approvalFromComments(comments []*github.IssueComment, approvers []string, minimumApprovals int) (approvalStatus, error) {
+func approvalFromComments(comments []*github.IssueComment, approvers []string, minimumApprovals int, allowCommentReasons bool) (approvalStatus, error) {
 	remainingApprovers := make([]string, len(approvers))
 	copy(remainingApprovers, approvers)
 
@@ -199,7 +201,7 @@ func approvalFromComments(comments []*github.IssueComment, approvers []string, m
 			continue
 		}
 
-		commentBody := comment.GetBody()
+		commentBody := decisionText(comment.GetBody(), allowCommentReasons)
 		isApprovalComment, err := isApproved(commentBody)
 		if err != nil {
 			return approvalStatusPending, err
@@ -223,6 +225,20 @@ func approvalFromComments(comments []*github.IssueComment, approvers []string, m
 	}
 
 	return approvalStatusPending, nil
+}
+
+// decisionText keeps the existing exact-comment behavior unless the optional
+// comment-reason mode is enabled. In that mode only the first line determines
+// the decision, so later lines can explain it without introducing ambiguous
+// approval or denial keywords.
+func decisionText(commentBody string, allowCommentReasons bool) string {
+	if !allowCommentReasons {
+		return commentBody
+	}
+
+	normalized := strings.ReplaceAll(commentBody, "\r\n", "\n")
+	firstLine, _, _ := strings.Cut(normalized, "\n")
+	return firstLine
 }
 
 func approversIndex(approvers []string, name string) int {

--- a/approval_test.go
+++ b/approval_test.go
@@ -25,6 +25,7 @@ func TestApprovalFromComments(t *testing.T) {
 		approvers        []string
 		minimumApprovals int
 		expectedStatus   approvalStatus
+		allowReasons     bool
 	}{
 		{
 			name: "single_approver_single_comment_approved",
@@ -58,6 +59,53 @@ func TestApprovalFromComments(t *testing.T) {
 			},
 			approvers:      []string{login1},
 			expectedStatus: approvalStatusPending,
+		},
+		{
+			name: "single_approver_approval_with_reason_enabled",
+			comments: []*github.IssueComment{
+				{
+					User: &github.User{Login: &login1},
+					Body: github.String("Approved.\nA later denied keyword is explanatory text only."),
+				},
+			},
+			approvers:      []string{login1},
+			expectedStatus: approvalStatusApproved,
+			allowReasons:   true,
+		},
+		{
+			name: "single_approver_denial_with_reason_enabled",
+			comments: []*github.IssueComment{
+				{
+					User: &github.User{Login: &login1},
+					Body: github.String("Denied!\r\nA later approved keyword is explanatory text only."),
+				},
+			},
+			approvers:      []string{login1},
+			expectedStatus: approvalStatusDenied,
+			allowReasons:   true,
+		},
+		{
+			name: "single_approver_reason_stays_pending_by_default",
+			comments: []*github.IssueComment{
+				{
+					User: &github.User{Login: &login1},
+					Body: github.String("Approved.\nThe deployment checks passed."),
+				},
+			},
+			approvers:      []string{login1},
+			expectedStatus: approvalStatusPending,
+		},
+		{
+			name: "decision_keyword_after_first_line_stays_pending",
+			comments: []*github.IssueComment{
+				{
+					User: &github.User{Login: &login1},
+					Body: github.String("Context first.\nApproved."),
+				},
+			},
+			approvers:      []string{login1},
+			expectedStatus: approvalStatusPending,
+			allowReasons:   true,
 		},
 		{
 			name: "single_approver_multi_comment_approved",
@@ -178,7 +226,7 @@ func TestApprovalFromComments(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual, err := approvalFromComments(testCase.comments, testCase.approvers, testCase.minimumApprovals)
+			actual, err := approvalFromComments(testCase.comments, testCase.approvers, testCase.minimumApprovals, testCase.allowReasons)
 			if err != nil {
 				t.Fatalf("error getting approval from comments: %v", err)
 			}

--- a/constants.go
+++ b/constants.go
@@ -28,6 +28,7 @@ const (
 	envVarTargetRepo                         string = "INPUT_TARGET-REPOSITORY"
 	envVarPollingIntervalSeconds             string = "INPUT_POLLING-INTERVAL-SECONDS"
 	envVarCloseIssueMeansDenial              string = "INPUT_CLOSE-ISSUE-MEANS-DENIAL"
+	envVarAllowCommentReasons                string = "INPUT_ALLOW-COMMENT-REASONS"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func newCommentLoopChannel(ctx context.Context, apprv *approvalEnvironment, clie
 				return
 			}
 
-			approved, err := approvalFromComments(comments, apprv.issueApprovers, apprv.minimumApprovals)
+			approved, err := approvalFromComments(comments, apprv.issueApprovers, apprv.minimumApprovals, apprv.allowCommentReasons)
 			if err != nil {
 				fmt.Printf("error getting approval from comments: %v\n", err)
 				channel <- 1
@@ -300,6 +300,16 @@ func main() {
 		}
 	}
 
+	allowCommentReasons := false
+	allowCommentReasonsRaw := os.Getenv(envVarAllowCommentReasons)
+	if allowCommentReasonsRaw != "" {
+		allowCommentReasons, err = strconv.ParseBool(allowCommentReasonsRaw)
+		if err != nil {
+			fmt.Printf("error parsing allow-comment-reasons: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
 	pollingInterval := defaultPollingInterval
 	pollingIntervalSecondsRaw := os.Getenv(envVarPollingIntervalSeconds)
 	if pollingIntervalSecondsRaw != "" {
@@ -346,7 +356,7 @@ func main() {
 	}
 	fmt.Printf("Parsed %d labels", len(issueLabels))
 
-	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals, issueTitle, issueBody, targetRepoOwner, targetRepoName, failOnDenial, closeIssueMeansDenial, issueLabels)
+	apprv, err := newApprovalEnvironment(client, repoFullName, repoOwner, runID, approvers, minimumApprovals, issueTitle, issueBody, targetRepoOwner, targetRepoName, failOnDenial, closeIssueMeansDenial, allowCommentReasons, issueLabels)
 	if err != nil {
 		fmt.Printf("error creating approval environment: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

- add an opt-in `allow-comment-reasons` input
- when enabled, read the approval or denial decision from the first line and allow explanatory text on later lines
- keep the input disabled by default so existing v1 exact-comment behavior is unchanged

Closes #21.

## Verification

- `go test -count=20 ./...`
- `go vet ./...`
- `go build ./...`
- `golangci-lint v2.10.1 run -v` (0 issues)
- parsed `action.yaml` and verified the new default is the string `false`
- ran the compiled action against a local fake GitHub API for three observable paths: approval with a reason, denial with a reason, and the default compatibility path where a reason-bearing comment remains pending until an exact approval comment arrives
- [public fork CI](https://github.com/CAOShurong/manual-approval/actions/runs/31874648952) passed the upstream Linux Docker build, tests, and v2.10.1 lint on exact head `6bd8130`

OpenAI Codex assisted with implementation and test execution. I reviewed the change and the reported results before submission.
